### PR TITLE
Increase lambda timeout to 30 seconds

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,7 @@ package:
 functions:
   api:
     handler: wsgi_handler.handler
+    timeout: 30
     events:
       - http:
           path: simple
@@ -72,6 +73,7 @@ functions:
             type: request
   s3:
     handler: elasticpypi.handler.s3
+    timeout: 30
     events:
       - s3:
           bucket: ${self:provider.environment.BUCKET}
@@ -81,6 +83,7 @@ functions:
           event: s3:ObjectCreated:*
   authorizer:
     handler: elasticpypi.handler.auth
+    timeout: 30
 
 custom:
   wsgi:


### PR DESCRIPTION
## Notes

It takes up to 5.5 seconds for DynamoDB to respond and default serverless timeout is 6 seconds. Increased to 30 as this is API gateway limit.

### Fixed

- Increased all Lambda functions timeouts to 30 seconds.